### PR TITLE
Add Listable#render to allow for full rendering customization

### DIFF
--- a/src/main/java/de/mineking/discordutils/list/ListManager.java
+++ b/src/main/java/de/mineking/discordutils/list/ListManager.java
@@ -5,7 +5,6 @@ import de.mineking.discordutils.Manager;
 import de.mineking.discordutils.commands.CommandManager;
 import de.mineking.discordutils.commands.context.ICommandContext;
 import de.mineking.discordutils.ui.MessageMenu;
-import de.mineking.discordutils.ui.MessageRenderer;
 import de.mineking.discordutils.ui.UIManager;
 import de.mineking.discordutils.ui.components.button.ButtonColor;
 import de.mineking.discordutils.ui.components.button.ButtonComponent;
@@ -81,7 +80,7 @@ public class ListManager<C extends ICommandContext> extends Manager {
 		}).asDisabled(s -> s.getState("page", int.class) == s.getCache("maxpage"))));
 		components.addAll(Arrays.asList(additionalComponents));
 
-		return uiManager.createMenu("list." + path, MessageRenderer.embed(s -> s.<Listable<T>>getCache("object").buildEmbed(s, s.getCache("context"))), components).cache(s -> {
+		return uiManager.createMenu("list." + path, (state, rows) -> state.<Listable<T>>getCache("object").render(state.getCache("context")).buildMessage(state, rows)).cache(s -> {
 			var o = object.apply(s);
 			s.setCache("object", o);
 

--- a/src/main/java/de/mineking/discordutils/list/ListManager.java
+++ b/src/main/java/de/mineking/discordutils/list/ListManager.java
@@ -95,7 +95,7 @@ public class ListManager<C extends ICommandContext> extends Manager {
 
 			setEntries(s);
 		}).effect("page", (state, name, old, n) -> {
-			if(old != null && toInt(old) == toInt(n)) return;
+			if (old != null && (int) old == (int) n) return;
 			setEntries((DataState<MessageMenu>) state);
 		});
 	}
@@ -113,10 +113,6 @@ public class ListManager<C extends ICommandContext> extends Manager {
 
 		context.entries().clear();
 		context.entries().addAll(entries.subList(((page - 1) * o.entriesPerPage()), Math.min((page * o.entriesPerPage()), entries.size())));
-	}
-
-	private Integer toInt(Object o) {
-		return o instanceof Double d ? d.intValue() : (int) o;
 	}
 
 	/**

--- a/src/main/java/de/mineking/discordutils/list/ListManager.java
+++ b/src/main/java/de/mineking/discordutils/list/ListManager.java
@@ -80,7 +80,7 @@ public class ListManager<C extends ICommandContext> extends Manager {
 		}).asDisabled(s -> s.getState("page", int.class) == s.getCache("maxpage"))));
 		components.addAll(Arrays.asList(additionalComponents));
 
-		return uiManager.createMenu("list." + path, (state, rows) -> state.<Listable<T>>getCache("object").render(state.getCache("context")).buildMessage(state, rows)).cache(s -> {
+		return uiManager.createMenu("list." + path, (state, rows) -> state.<Listable<T>>getCache("object").render(state.getCache("context")).buildMessage(state, rows), components).cache(s -> {
 			var o = object.apply(s);
 			s.setCache("object", o);
 

--- a/src/main/java/de/mineking/discordutils/list/Listable.java
+++ b/src/main/java/de/mineking/discordutils/list/Listable.java
@@ -1,6 +1,7 @@
 package de.mineking.discordutils.list;
 
 import de.mineking.discordutils.ui.MessageMenu;
+import de.mineking.discordutils.ui.MessageRenderer;
 import de.mineking.discordutils.ui.state.DataState;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -62,5 +63,14 @@ public interface Listable<T extends ListEntry> {
 		finalizeEmbed(embed, state, context);
 
 		return embed.build();
+	}
+
+	/**
+	 * @param context The {@link ListContext}
+	 * @return A {@link MessageRenderer} that renders the actual message. The default implementation uses {@link #createEmbed(DataState, ListContext)}, {@link #buildEmbed(DataState, ListContext)} and {@link #finalizeEmbed(EmbedBuilder, DataState, ListContext)}
+	 */
+	@NotNull
+	default MessageRenderer render(@NotNull ListContext<T> context) {
+		return MessageRenderer.embed(s -> buildEmbed(s, context));
 	}
 }

--- a/src/main/java/de/mineking/discordutils/ui/state/State.java
+++ b/src/main/java/de/mineking/discordutils/ui/state/State.java
@@ -53,7 +53,7 @@ public abstract class State<M extends Menu> {
 	 */
 	@NotNull
 	public <T> State<M> setState(@NotNull String name, @Nullable T value) {
-		return setState(name, Object.class, old -> value);
+		return setState(name, value == null ? Object.class : value.getClass(), old -> value);
 	}
 
 	/**

--- a/src/main/java/de/mineking/discordutils/ui/state/UpdateState.java
+++ b/src/main/java/de/mineking/discordutils/ui/state/UpdateState.java
@@ -51,16 +51,22 @@ public class UpdateState extends DataState<MessageMenu> {
 	}
 
 	/**
-	 * Disables all components and then re-renders the menu. This should be used if your rendering takes very long
+	 * Disables all components and waits for an actual rerender using {@link #instantUpdate()}
 	 */
-	public void update() {
-		if(event == null || !(event instanceof GenericComponentInteractionCreateEvent evt)) return;
+	public void deferUpdate() {
+		if (event == null || !(event instanceof GenericComponentInteractionCreateEvent evt)) return;
 
 		var components = evt.getMessage().getComponents().stream().map(a -> ActionRow.of(a.getComponents().stream().map(c -> c instanceof ActionComponent ac ? ac.withDisabled(true) : c).toList())).toList();
 
-		if(!evt.isAcknowledged()) evt.editComponents(components).queue();
+		if (!evt.isAcknowledged()) evt.editComponents(components).queue();
 		else evt.getHook().editOriginalComponents(components).queue();
+	}
 
+	/**
+	 * Disables all components and then re-renders the menu. This should be used if your rendering takes very long
+	 */
+	public void update() {
+		deferUpdate();
 		instantUpdate();
 	}
 

--- a/src/test/java/list/ListBot.java
+++ b/src/test/java/list/ListBot.java
@@ -31,7 +31,10 @@ public class ListBot {
 						AutocompleteContext::new,
 						CommandManager::updateCommands
 				)
-				.useListManager(config -> config.getManager().getCommandManager().registerCommand(config.createCommand(state -> new TestList(), new ButtonComponent("test", ButtonColor.GRAY, "TEST").appendHandler(UpdateState::update)).withName("list_test")))
+				.useListManager(config -> config.getManager().getCommandManager().registerCommand(config.createCommand(
+						state -> new TestList(),
+						new ButtonComponent("test", ButtonColor.GRAY, "TEST").appendHandler(UpdateState::update)
+				).withName("list_test")))
 				.build();
 
 		this.jda = discordUtils.getJDA();


### PR DESCRIPTION
Allows to fully customize `Listable` message rendering by adding a `render` method that returns a `MessageRenderer`. This can be useful if you want to upload files